### PR TITLE
Fix typescript build error on vercel

### DIFF
--- a/TEACHING_SLIDES_README.md
+++ b/TEACHING_SLIDES_README.md
@@ -661,9 +661,10 @@ Last reviewed: 2025-09-09
 - Web (Vercel):
   - App root: `app/`
   - Build Command: `npm ci && npm run build`
-  - Output: `dist/`
+  - Output: `build/` (Create React App)
   - Env on Vercel: set `EXPO_PUBLIC_API_HOST=<your-backend-domain>` and WorkOS `EXPO_PUBLIC_*`
   - `app/vercel.json` includes a rewrite to proxy `/api/*` to your backend; replace `YOUR_BACKEND_DOMAIN`.
+  - Note on TS builds: Ensure callbacks used in hook deps are declared before use. A recent fix moved `startTimeTracking`/`stopTimeTracking` above `playAudio` in `app/src/components/ai-teacher/AITeacherSession.tsx` to resolve `TS2448: Block-scoped variable used before its declaration` during Vercel builds.
 
 - Backend (Render):
   - Root: `server/`

--- a/app/src/components/ai-teacher/AITeacherSession.tsx
+++ b/app/src/components/ai-teacher/AITeacherSession.tsx
@@ -167,7 +167,30 @@ export const AITeacherSession: React.FC<AITeacherSessionProps> = ({
     })
   }, [topic, userId])
 
-  // Audio playback controls
+  
+
+  const startTimeTracking = useCallback(() => {
+    stopTimeTracking()
+    timeIntervalRef.current = setInterval(() => {
+      if (audioRef.current) {
+        const newTime = audioRef.current.currentTime
+        // Only update if time has changed significantly to prevent excessive re-renders
+        setTimeSeconds(prevTime => {
+          const diff = Math.abs(newTime - prevTime)
+          return diff > 0.1 ? newTime : prevTime
+        })
+      }
+    }, 100) // Increased update frequency for smoother motion
+  }, [])
+
+  const stopTimeTracking = useCallback(() => {
+    if (timeIntervalRef.current) {
+      clearInterval(timeIntervalRef.current)
+      timeIntervalRef.current = undefined
+    }
+  }, [])
+
+  // Audio playback controls (moved below time tracking callbacks to avoid TS2448)
   const playAudio = useCallback((audioUrl: string) => {
     // If same URL and already attached, just ensure it's playing
     if (currentAudioUrlRef.current === audioUrl && audioRef.current) {
@@ -229,27 +252,6 @@ export const AITeacherSession: React.FC<AITeacherSessionProps> = ({
       setIsPlaying(false)
     })
   }, [startTimeTracking, stopTimeTracking])
-
-  const startTimeTracking = useCallback(() => {
-    stopTimeTracking()
-    timeIntervalRef.current = setInterval(() => {
-      if (audioRef.current) {
-        const newTime = audioRef.current.currentTime
-        // Only update if time has changed significantly to prevent excessive re-renders
-        setTimeSeconds(prevTime => {
-          const diff = Math.abs(newTime - prevTime)
-          return diff > 0.1 ? newTime : prevTime
-        })
-      }
-    }, 100) // Increased update frequency for smoother motion
-  }, [])
-
-  const stopTimeTracking = useCallback(() => {
-    if (timeIntervalRef.current) {
-      clearInterval(timeIntervalRef.current)
-      timeIntervalRef.current = undefined
-    }
-  }, [])
 
   const togglePlayPause = useCallback(() => {
     if (!audioRef.current) return


### PR DESCRIPTION
Reorder `startTimeTracking` and `stopTimeTracking` callbacks to resolve `TS2448` build error.

The `startTimeTracking` and `stopTimeTracking` `useCallback` declarations were referenced in a `useEffect` and called within `playAudio` before their actual declaration, causing a TypeScript compilation error during Vercel builds. This change moves their declarations to ensure they are defined before use. Additionally, the Vercel build output directory was corrected in the README.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f2924cc-6123-4254-b5ed-2955778e206d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f2924cc-6123-4254-b5ed-2955778e206d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

