### PR TITLE
Fix lucid-ai.co domain redirects

### DIFF
--- a/WORKOS_SETUP.md
+++ b/WORKOS_SETUP.md
@@ -23,10 +23,12 @@ This guide will help you set up WorkOS AuthKit authentication for the Lucid app,
 ### 1.2 Configure Redirect URIs
 
 1. In your WorkOS application settings, go to the "Redirects" section
-2. Add the following redirect URIs:
-   - **Redirect URI**: `http://localhost:8081/auth/callback` (for web app)
-   - **Login Endpoint**: `http://localhost:3001/auth/workos/login` (for backend)
-   - **Logout Redirect**: `http://localhost:8081/auth/logout` (for web app)
+2. Add the redirect URIs for every environment that can initiate auth:
+   - **Development**: `http://localhost:3000/auth/callback`
+   - **Preview / Staging**: e.g. `https://lucidai-eight.vercel.app/auth/callback`
+   - **Custom domain**: e.g. `https://lucid-ai.co/auth/callback`
+3. Set the **Login endpoint** to your deployed backend, for example `https://lucidai-m3m2.vercel.app/auth/workos/authorize`
+4. Add logout targets that match the same origins, such as `https://lucid-ai.co`
 
 ### 1.3 Get Your Credentials
 
@@ -83,16 +85,22 @@ The `server/src/modules/auth.module.ts` has been updated to include WorkOS servi
 
 ## Step 3: Frontend Configuration
 
-### 3.1 Environment Variables
+### 3.1 Environment Variables (React Web)
 
 Create a `.env` file in the `app` directory with the following variables:
 
 ```env
 # WorkOS Configuration
-EXPO_PUBLIC_WORKOS_CLIENT_ID=client_your_workos_client_id_here
-EXPO_PUBLIC_WORKOS_BASE_URL=http://localhost:3001
-EXPO_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:8081/auth/callback
+REACT_APP_WORKOS_CLIENT_ID=client_your_workos_client_id_here
+REACT_APP_WORKOS_BASE_URL=http://localhost:3001
+REACT_APP_WORKOS_ALLOWED_REDIRECT_URIS=http://localhost:3000/auth/callback,https://lucidai-eight.vercel.app/auth/callback,https://lucid-ai.co/auth/callback
+REACT_APP_WORKOS_CALLBACK_PATH=/auth/callback
+
+# Optional: fallback redirect if you prefer a single static value
+# REACT_APP_WORKOS_REDIRECT_URI=https://lucid-ai.co/auth/callback
 ```
+
+> The frontend automatically prefers the current browser origin when it matches the allow list, so the same build can serve every approved domain without rebuilds.
 
 ### 3.2 Frontend Files Created
 
@@ -189,9 +197,9 @@ For production, update the environment variables:
 WORKOS_API_KEY=sk_live_your_production_api_key
 WORKOS_CLIENT_ID=client_your_production_client_id
 WORKOS_COOKIE_PASSWORD=your_production_cookie_password
-
-# Update redirect URIs for production
-EXPO_PUBLIC_WORKOS_REDIRECT_URI=https://yourdomain.com/auth/callback
+WORKOS_REDIRECT_URI=https://lucid-ai.co/auth/callback
+FRONTEND_URL=https://lucid-ai.co
+WORKOS_ALLOWED_REDIRECT_URIS=https://lucid-ai.co/auth/callback,https://lucidai-eight.vercel.app/auth/callback
 ```
 
 ### 7.2 Update WorkOS Dashboard

--- a/app/env.example
+++ b/app/env.example
@@ -2,6 +2,8 @@
 REACT_APP_WORKOS_CLIENT_ID=client_your_workos_client_id_here
 REACT_APP_WORKOS_BASE_URL=http://localhost:3001
 REACT_APP_WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
+REACT_APP_WORKOS_ALLOWED_REDIRECT_URIS=http://localhost:3000/auth/callback
+REACT_APP_WORKOS_CALLBACK_PATH=/auth/callback
 
 # API Configuration
 REACT_APP_API_BASE_URL=http://localhost:3001

--- a/app/src/components/ProtectedRoute.tsx
+++ b/app/src/components/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { workosAuthService } from '../services/workosAuthService';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -41,9 +42,9 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   }
 
   if (!isAuthenticated) {
-    // Redirect to WorkOS custom login endpoint
-    const redirectUri = `${window.location.origin}/auth/callback`;
-    const loginUrl = `${process.env.REACT_APP_WORKOS_BASE_URL || 'http://localhost:3001'}/auth/workos/authorize?redirectUri=${encodeURIComponent(redirectUri)}`;
+    // Redirect to WorkOS custom login endpoint using runtime-safe redirect URI
+    const redirectUri = workosAuthService.getRedirectUri();
+    const loginUrl = `${workosAuthService.getBaseUrl()}/auth/workos/authorize?redirectUri=${encodeURIComponent(redirectUri)}`;
     window.location.href = loginUrl;
     return null;
   }

--- a/app/src/services/workosAuthService.ts
+++ b/app/src/services/workosAuthService.ts
@@ -24,23 +24,123 @@ class WorkOSAuthService {
   private clientId: string;
   private baseUrl: string;
   private redirectUri: string;
+  private allowedRedirectUris: string[];
+  private normalizedAllowedRedirectUris: string[];
+  private callbackPath: string;
 
   constructor() {
     this.clientId = process.env.REACT_APP_WORKOS_CLIENT_ID || '';
-    this.baseUrl = process.env.REACT_APP_WORKOS_BASE_URL || process.env.REACT_APP_API_BASE_URL || 'http://localhost:3001';
-    this.redirectUri = process.env.REACT_APP_WORKOS_REDIRECT_URI ||
-      (typeof window !== 'undefined' && window.location?.origin ? `${window.location.origin}/auth/callback` : 'http://localhost:3000/auth/callback');
+    const configuredBaseUrl = process.env.REACT_APP_WORKOS_BASE_URL || process.env.REACT_APP_API_BASE_URL || 'http://localhost:3001';
+    this.baseUrl = configuredBaseUrl.replace(/\/+$/, '');
+    this.callbackPath = this.normalizeCallbackPath(process.env.REACT_APP_WORKOS_CALLBACK_PATH);
+    this.allowedRedirectUris = this.buildAllowedRedirectUris();
+    this.normalizedAllowedRedirectUris = this.allowedRedirectUris.map((uri) => this.normalizeForComparison(uri));
+    this.redirectUri = this.resolveRedirectUri();
     
     if (!this.clientId) {
       console.error('REACT_APP_WORKOS_CLIENT_ID is required');
     }
   }
 
+  private normalizeCallbackPath(path?: string): string {
+    const value = (path && path.trim()) || '/auth/callback';
+    if (!value.startsWith('/')) {
+      return `/${value.replace(/^\/*/, '')}`;
+    }
+    return value.replace(/\/$/, '');
+  }
+
+  private buildAllowedRedirectUris(): string[] {
+    const rawList = [
+      process.env.REACT_APP_WORKOS_REDIRECT_URI,
+      process.env.REACT_APP_WORKOS_ALLOWED_REDIRECT_URIS,
+    ]
+      .filter(Boolean)
+      .join(',');
+
+    return rawList
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  private normalizeForComparison(uri: string): string {
+    try {
+      const parsed = new URL(uri);
+      parsed.hash = '';
+      // Remove trailing slash for comparison consistency
+      parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+      return parsed.toString();
+    } catch (error) {
+      console.warn('Invalid redirect URI encountered while normalizing:', uri, error);
+      return uri.trim();
+    }
+  }
+
+  private buildRuntimeRedirectUri(): string | null {
+    if (typeof window === 'undefined' || !window.location?.origin) {
+      return null;
+    }
+    const origin = window.location.origin.replace(/\/+$/, '');
+    return `${origin}${this.callbackPath}`;
+  }
+
+  private resolveRedirectUri(): string {
+    const runtimeRedirect = this.buildRuntimeRedirectUri();
+
+    if (runtimeRedirect) {
+      const runtimeMatches = this.normalizedAllowedRedirectUris.includes(
+        this.normalizeForComparison(runtimeRedirect)
+      );
+
+      if (runtimeMatches || this.normalizedAllowedRedirectUris.length === 0) {
+        return runtimeRedirect;
+      }
+
+      console.warn(
+        '[WorkOS] Runtime redirect URI is not in the configured allow list. Falling back to first allowed URI.',
+        {
+          runtimeRedirect,
+          allowedRedirectUris: this.allowedRedirectUris,
+        }
+      );
+    }
+
+    if (this.allowedRedirectUris.length > 0) {
+      return this.allowedRedirectUris[0];
+    }
+
+    // Final fallback for development environments
+    return 'http://localhost:3000/auth/callback';
+  }
+
+  getRedirectUri(): string {
+    const runtimeRedirect = this.buildRuntimeRedirectUri();
+    if (runtimeRedirect) {
+      const runtimeNormalized = this.normalizeForComparison(runtimeRedirect);
+      const currentNormalized = this.normalizeForComparison(this.redirectUri);
+
+      const runtimeAllowed =
+        this.normalizedAllowedRedirectUris.length === 0 ||
+        this.normalizedAllowedRedirectUris.includes(runtimeNormalized);
+
+      if (runtimeAllowed && runtimeNormalized !== currentNormalized) {
+        this.redirectUri = runtimeRedirect;
+      }
+    }
+
+    return this.redirectUri;
+  }
+
+  getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
   // Get authorization URL from backend
   async getAuthorizationUrl(): Promise<string> {
     try {
       const url = new URL(`${this.baseUrl}/auth/workos/authorize`);
-      url.searchParams.set('redirectUri', this.redirectUri);
+      url.searchParams.set('redirectUri', this.getRedirectUri());
       
       const response = await fetch(url.toString(), {
         method: 'GET',
@@ -73,7 +173,7 @@ class WorkOSAuthService {
           code,
           state,
           clientId: this.clientId,
-          redirectUri: this.redirectUri,
+          redirectUri: this.getRedirectUri(),
         }),
       });
 

--- a/server/env.example
+++ b/server/env.example
@@ -16,6 +16,7 @@ WORKOS_API_KEY=your_workos_api_key_here
 WORKOS_CLIENT_ID=client_your_workos_client_id_here
 WORKOS_COOKIE_PASSWORD=your_32_character_cookie_password_here
 WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
+WORKOS_ALLOWED_REDIRECT_URIS=http://localhost:3000/auth/callback
 
 # Python AI Services Configuration
 QNA_AGENT_URL=http://localhost:8001

--- a/server/src/controllers/workos-auth.controller.ts
+++ b/server/src/controllers/workos-auth.controller.ts
@@ -73,7 +73,11 @@ export class WorkOSAuthController {
       return { authorizationUrl };
     } catch (error) {
       console.error('🔍 WorkOS - Error in GET /authorize:', error);
-      throw new BadRequestException('Failed to generate authorization URL');
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Failed to generate authorization URL';
+      throw new BadRequestException(message);
     }
   }
 
@@ -106,7 +110,11 @@ export class WorkOSAuthController {
       return { authorizationUrl };
     } catch (error) {
       console.error('Error generating authorization URL:', error);
-      throw new BadRequestException('Failed to generate authorization URL');
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Failed to generate authorization URL';
+      throw new BadRequestException(message);
     }
   }
 
@@ -148,7 +156,11 @@ export class WorkOSAuthController {
       return result;
     } catch (error) {
       console.error('Error handling auth callback:', error);
-      throw new BadRequestException('Authentication callback failed');
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Authentication callback failed';
+      throw new BadRequestException(message);
     }
   }
 

--- a/server/src/services/workos-auth.service.ts
+++ b/server/src/services/workos-auth.service.ts
@@ -32,6 +32,8 @@ export class WorkOSAuthService {
   private apiKey: string;
   private cookiePassword: string;
   private clientId: string;
+  private allowedRedirectUris: string[];
+  private normalizedAllowedRedirectUris: string[];
 
   constructor(
     private configService: ConfigService,
@@ -57,6 +59,16 @@ export class WorkOSAuthService {
     this.apiKey = apiKey;
     this.cookiePassword = cookiePassword;
     this.clientId = clientId;
+    const allowedRedirectEnv = this.configService.get<string>('WORKOS_ALLOWED_REDIRECT_URIS');
+    this.allowedRedirectUris = allowedRedirectEnv
+      ? allowedRedirectEnv
+          .split(',')
+          .map((uri) => uri.trim())
+          .filter(Boolean)
+      : [];
+    this.normalizedAllowedRedirectUris = this.allowedRedirectUris.map((uri) =>
+      this.normalizeForComparison(uri)
+    );
     // Pass clientId when initializing the SDK (required by session helpers)
     this.workos = new WorkOS(this.apiKey, { clientId: this.clientId });
   }
@@ -73,7 +85,8 @@ export class WorkOSAuthService {
         (this.configService.get<string>('FRONTEND_URL')
           ? `${this.configService.get<string>('FRONTEND_URL')!.replace(/\/$/, '')}/auth/callback`
           : undefined);
-      const redirectUri = params.redirectUri || envRedirect;
+      const redirectCandidate = params.redirectUri || envRedirect;
+      const redirectUri = this.ensureRedirectAllowed(redirectCandidate);
       
       console.log('🔍 WorkOS - Generating authorization URL with:', { clientId, redirectUri });
       
@@ -101,6 +114,7 @@ export class WorkOSAuthService {
   }): Promise<WorkOSAuthResult> {
     try {
       const { code, state, clientId, redirectUri } = params;
+      this.ensureRedirectAllowed(redirectUri);
 
       // Authenticate with WorkOS using the authorization code
       const authenticateResponse = await this.workos.userManagement.authenticateWithCode({
@@ -316,6 +330,37 @@ export class WorkOSAuthService {
   private generateState(): string {
     // Generate a random state parameter for security
     return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+  }
+
+  private normalizeForComparison(uri: string): string {
+    try {
+      const parsed = new URL(uri);
+      parsed.hash = '';
+      parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+      return parsed.toString();
+    } catch (error) {
+      console.warn('Invalid WORKOS redirect URI configured:', uri, error);
+      return uri.trim();
+    }
+  }
+
+  private ensureRedirectAllowed(redirectUri?: string): string {
+    if (!redirectUri) {
+      throw new Error('Redirect URI is required');
+    }
+
+    if (this.normalizedAllowedRedirectUris.length === 0) {
+      return redirectUri;
+    }
+
+    const normalized = this.normalizeForComparison(redirectUri);
+    if (!this.normalizedAllowedRedirectUris.includes(normalized)) {
+      throw new Error(
+        `Redirect URI "${redirectUri}" is not allowed. Update WORKOS_ALLOWED_REDIRECT_URIS to include it.`
+      );
+    }
+
+    return redirectUri;
   }
 
   private async findOrCreateWorkOSUser(workOSUser: WorkOSUser): Promise<WorkOSUser> {


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-f8a1fb77-7b42-460f-8569-b79a0a37d80c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8a1fb77-7b42-460f-8569-b79a0a37d80c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements runtime-resolved redirect URIs with allow-listing and backend enforcement for WorkOS AuthKit, updating envs, docs, and the login flow.
> 
> - **Auth Redirects**
>   - Implement runtime-safe redirect resolution in `app/src/services/workosAuthService.ts`, preferring current origin when allowed, with normalization and fallbacks.
>   - Enforce allowed redirect URIs on the backend in `server/src/services/workos-auth.service.ts` using `WORKOS_ALLOWED_REDIRECT_URIS` and normalization; validate in `getAuthorizationUrl` and `handleCallback`.
> - **Frontend**
>   - `ProtectedRoute`: use `workosAuthService.getRedirectUri()` and `getBaseUrl()` for WorkOS login redirect.
>   - `workosAuthService`: add allow-list parsing, callback path support, normalized comparisons, and use resolved redirect in requests.
> - **Backend**
>   - `workos-auth.controller.ts`: propagate detailed error messages for authorize/callback endpoints.
> - **Config & Docs**
>   - Update `WORKOS_SETUP.md` with multi-environment redirect guidance, login/logout endpoints, and React web env vars.
>   - Update `app/env.example` and `server/env.example` to include `REACT_APP_WORKOS_ALLOWED_REDIRECT_URIS`, `REACT_APP_WORKOS_CALLBACK_PATH`, and `WORKOS_ALLOWED_REDIRECT_URIS`; add production values for `WORKOS_REDIRECT_URI` and `FRONTEND_URL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 287f3859f6c0777d44b4cc9645e712594aa3a3f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->