### PR TITLE
Fix google sign in verification failure

### DIFF
--- a/TEACHING_SLIDES_README.md
+++ b/TEACHING_SLIDES_README.md
@@ -68,6 +68,7 @@ cd app && npm i @babel/standalone --save
 ### 🔐 WorkOS Auth Callback CORS Hardening — FIXED (Latest)
 - Problem: WorkOS redirects succeeded, but the final callback request from `https://lucid-ai.co` to the NestJS backend failed with browser `TypeError: Failed to fetch` because the custom domain was not whitelisted for CORS and some deployments still pointed the web app at `http://localhost:3001`.
 - Fix: Added a shared `buildCorsOrigins` helper so both the Node server (`main.ts`) and the Vercel serverless entrypoint (`api/index.ts`) automatically import origins from env (`CORS_ORIGIN(S)`, `FRONTEND_URL`, `WORKOS_REDIRECT_URI`, `WORKOS_ALLOWED_REDIRECT_URIS`, Vercel production URLs). Updated the React `workosAuthService` to resolve its base URL intelligently—preferring env values, then the runtime origin for production, with a guarded localhost fallback for dev.
+- Update: `buildCorsOrigins` now ships with a default allow-list regex for `https://lucid-ai.co` (and subdomains) so the production custom domain is covered even if env vars lag behind a domain change.
 - Impact: The WorkOS callback and session validation complete successfully on Vercel custom domains without manual CORS tweaks. Production users now land in the app instead of the error card.
 
 ### 🌐 Backend on Vercel (serverless) — FIXED (Latest)

--- a/server/src/utils/cors.util.ts
+++ b/server/src/utils/cors.util.ts
@@ -10,6 +10,7 @@ const DEFAULT_CORS_ORIGINS: (string | RegExp)[] = [
   /^http:\/\/172\.\d+\.\d+\.\d+:(19000|19006|8081)$/,
   /^http:\/\/127\.0\.0\.1:\d+$/,
   /^https:\/\/[a-z0-9-]+\.vercel\.app$/,
+  /^https:\/\/([a-z0-9-]+\.)?lucid-ai\.co$/i,
 ];
 
 const asOrigin = (value?: string | null): string | null => {


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-d60857eb-0b41-4942-940f-1d37e03b44ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d60857eb-0b41-4942-940f-1d37e03b44ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `lucid-ai.co` (and subdomains) to default CORS origins and updates README to reflect the new allowlist.
> 
> - **Backend**:
>   - **CORS**: Add default allowlist entry for `https://lucid-ai.co` and subdomains via regex in `server/src/utils/cors.util.ts` (`DEFAULT_CORS_ORIGINS`).
> - **Docs**:
>   - Update `TEACHING_SLIDES_README.md` to note the new default CORS allowlist for the production custom domain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc12d089407d6731364c6390ec7ea248e6c64228. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->